### PR TITLE
Feat: 채용공고 수정 기능 추가

### DIFF
--- a/src/main/java/com/wanted/controller/JobPostingController.java
+++ b/src/main/java/com/wanted/controller/JobPostingController.java
@@ -1,5 +1,6 @@
 package com.wanted.controller;
 
+import com.wanted.dto.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.*;
 import com.wanted.service.JobPostingService;
 import io.swagger.annotations.Api;
@@ -12,8 +13,7 @@ import javax.validation.Valid;
 
 import java.util.List;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/job-postings")
@@ -54,6 +54,17 @@ public class JobPostingController {
 
         return ResponseEntity.status(OK)
                 .body(JobPostingDetailResponse.from(jobPostingDetailDto));
+    }
+
+    @PatchMapping("/{id}")
+    @ApiOperation(value = "채용공고 수정", notes = "채용공고 내용을 수정합니다. (수정안하는 필드는 null로 보내주세요.)")
+    public ResponseEntity<Void> modifyJobPosting(
+            @PathVariable Long id,
+            @Valid @RequestBody JobPostingModificationRequest jobPostingModificationRequestDto) {
+
+        jobPostingService.modifyJobPosting(id,jobPostingModificationRequestDto);
+
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/com/wanted/dto/JobPostingModificationRequest.java
+++ b/src/main/java/com/wanted/dto/JobPostingModificationRequest.java
@@ -1,0 +1,21 @@
+package com.wanted.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JobPostingModificationRequest {
+    private String title;
+    private String imageUrl;
+    private String position;
+    private Long reward;
+    private String content;
+    private List<String> techStacks;
+}

--- a/src/main/java/com/wanted/model/JobPosting.java
+++ b/src/main/java/com/wanted/model/JobPosting.java
@@ -52,4 +52,25 @@ public class JobPosting extends BaseEntity {
                 .company(company)
                 .build();
     }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public void setReward(Long reward) {
+        this.reward = reward;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setTechStacks(List<String> techStacks) {
+        this.techStacks = techStacks;
+    }
+
 }

--- a/src/main/java/com/wanted/service/JobPostingService.java
+++ b/src/main/java/com/wanted/service/JobPostingService.java
@@ -1,6 +1,10 @@
 package com.wanted.service;
 
-import com.wanted.dto.jobposting.*;
+import com.wanted.dto.JobPostingModificationRequest;
+import com.wanted.dto.jobposting.JobPostingDetailDto;
+import com.wanted.dto.jobposting.JobPostingDto;
+import com.wanted.dto.jobposting.JobPostingRegistrationRequest;
+import com.wanted.dto.jobposting.JobPostingRelationsDto;
 import com.wanted.exception.CustomException;
 import com.wanted.exception.ErrorCode;
 import com.wanted.model.Company;
@@ -13,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -52,6 +57,28 @@ public class JobPostingService {
                         .collect(Collectors.toList());
 
         return JobPostingDetailDto.from(targetJobPosting, relations);
+    }
+
+    public void modifyJobPosting(Long id,
+                                 JobPostingModificationRequest ModificationRequestDto) {
+
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        // 빈값이거나 null 이 아닌 경우에만 수정
+        updateIfNotNull(jobPosting::setContent, ModificationRequestDto.getContent());
+        updateIfNotNull(jobPosting::setImageUrl, ModificationRequestDto.getImageUrl());
+        updateIfNotNull(jobPosting::setReward, ModificationRequestDto.getReward());
+        updateIfNotNull(jobPosting::setPosition, ModificationRequestDto.getPosition());
+        updateIfNotNull(jobPosting::setTechStacks, ModificationRequestDto.getTechStacks());
+
+        jobPostingRepository.save(jobPosting);
+    }
+
+    private <T> void updateIfNotNull(Consumer<T> setter, T value) {
+        if (value != null && (!(value instanceof String) || !((String) value).isEmpty())) {
+            setter.accept(value);
+        }
     }
 
 }

--- a/src/test/java/com/wanted/service/JobPostingServiceTest.java
+++ b/src/test/java/com/wanted/service/JobPostingServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.service;
 
+import com.wanted.dto.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.JobPostingDetailDto;
 import com.wanted.dto.jobposting.JobPostingDto;
 import com.wanted.dto.jobposting.JobPostingRegistrationRequest;
@@ -230,6 +231,55 @@ public class JobPostingServiceTest {
         assertThatThrownBy(() -> jobPostingService.getJobPostingDetails(nonExistentCompanyId))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.JOB_POSTING_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("채용공고 정보 수정 - 성공")
+    void testModifyJobPosting_success() {
+        // Give
+        JobPosting targetJobPosting = JobPosting.builder()
+                .id(1L)
+                .title("테스트 공고")
+                .company(Company.builder()
+                        .id(1L)
+                        .email("test@naver.com")
+                        .phone("010-1234-1234")
+                        .address("서울시 강남구")
+                        .name("테스트")
+                        .businessNumber("123-45-67890")
+                        .build())
+                .content("테스트입니다")
+                .imageUrl("테스트입니다")
+                .position("대리")
+                .reward(50000L)
+                .techStacks(Arrays.asList("Java", "Spring"))
+                .build();
+
+        JobPostingModificationRequest modificationRequestDto =
+                JobPostingModificationRequest.builder()
+                        .content("변경입니다")
+                        .imageUrl("변경입니다")
+                        .reward(1000L)
+                        .position("")
+                        .title(null)
+                        .techStacks(Arrays.asList("변경1" , "변경2"))
+                        .build();
+
+        when(jobPostingRepository.findById(targetJobPosting.getId()))
+                .thenReturn(Optional.of(targetJobPosting));
+
+        // When
+        jobPostingService.modifyJobPosting(
+                targetJobPosting.getId(), modificationRequestDto
+        );
+
+        // Then
+        assertThat(targetJobPosting.getContent()).isEqualTo("변경입니다");
+        assertThat(targetJobPosting.getImageUrl()).isEqualTo("변경입니다");
+        assertThat(targetJobPosting.getReward()).isEqualTo(1000);
+        assertThat(targetJobPosting.getPosition()).isEqualTo("대리");
+        assertThat(targetJobPosting.getTechStacks()).isEqualTo(Arrays.asList("변경1", "변경2"));
+        verify(jobPostingRepository, times(1)).save(targetJobPosting);
     }
 
 }


### PR DESCRIPTION
### 작업 내용
- 업로드한 채용공고를 수정하는 기능 추가
### 변경 사항(추가시엔 추가사항)
- 수정하능한 필드를 `null`이 아닌 값을 넣어 요청하면 수정처리.
- 다른말로, `null`로 온 값들은 수정하지 않음. 
### 특이 사항
- 개인적으로 제네릭을 처음 사용해봤는데 매우 편리하고 앞으로도 코딩 시 자주 사용할 것 같음.