### PR TITLE
Feat: 이미지 업로드/삭제 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'javax.validation:validation-api:2.0.1.Final'
     //Hibernate Validator
     implementation 'org.hibernate:hibernate-validator:7.0.1.Final'
+    //s3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/wanted/config/S3Config.java
+++ b/src/main/java/com/wanted/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.wanted.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/controller/ImageController.java
+++ b/src/main/java/com/wanted/controller/ImageController.java
@@ -1,0 +1,37 @@
+package com.wanted.controller;
+
+import com.wanted.dto.ImageUrlResponse;
+import com.wanted.enums.ImageDirectory;
+import com.wanted.service.ImageService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+@Api(tags = "이미지관련 API", description = "이미지 업로드/삭제 API")
+@RestController
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @ApiOperation(
+            value = "이미지 업로드",
+            notes = "이미지를 업로드하고 URL을 반환합니다.(받은 URL을 JobPosting 생성 시에 사용하세요.)"
+    )
+    public ResponseEntity<ImageUrlResponse> uploadImage(
+            MultipartFile image, ImageDirectory imageDirectory) throws Exception {
+
+        String ImageUrl = imageService.saveFile(image, imageDirectory);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ImageUrlResponse.builder().imageUrl(ImageUrl).build());
+    }
+}

--- a/src/main/java/com/wanted/controller/JobPostingController.java
+++ b/src/main/java/com/wanted/controller/JobPostingController.java
@@ -1,5 +1,6 @@
 package com.wanted.controller;
 
+import com.wanted.dto.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.*;
 import com.wanted.service.JobPostingService;
 import io.swagger.annotations.Api;
@@ -12,8 +13,7 @@ import javax.validation.Valid;
 
 import java.util.List;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/job-postings")
@@ -54,6 +54,17 @@ public class JobPostingController {
 
         return ResponseEntity.status(OK)
                 .body(JobPostingDetailResponse.from(jobPostingDetailDto));
+    }
+
+    @PatchMapping("/{id}")
+    @ApiOperation(value = "채용공고 수정", notes = "채용공고 내용을 수정합니다. (수정안하는 필드는 null로 보내주세요.)")
+    public ResponseEntity<Void> modifyJobPosting(
+            @PathVariable Long id,
+            @Valid @RequestBody JobPostingModificationRequest jobPostingModificationRequestDto) {
+
+        jobPostingService.modifyJobPosting(id,jobPostingModificationRequestDto);
+
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/com/wanted/dto/ImageUrlResponse.java
+++ b/src/main/java/com/wanted/dto/ImageUrlResponse.java
@@ -1,0 +1,14 @@
+package com.wanted.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ImageUrlResponse {
+    private String imageUrl;
+}

--- a/src/main/java/com/wanted/dto/JobPostingModificationRequest.java
+++ b/src/main/java/com/wanted/dto/JobPostingModificationRequest.java
@@ -1,0 +1,21 @@
+package com.wanted.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JobPostingModificationRequest {
+    private String title;
+    private String imageUrl;
+    private String position;
+    private Long reward;
+    private String content;
+    private List<String> techStacks;
+}

--- a/src/main/java/com/wanted/enums/ImageDirectory.java
+++ b/src/main/java/com/wanted/enums/ImageDirectory.java
@@ -1,0 +1,11 @@
+package com.wanted.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ImageDirectory {
+    JOB_POSTING("job-posting");
+    private final String string;
+}

--- a/src/main/java/com/wanted/model/JobPosting.java
+++ b/src/main/java/com/wanted/model/JobPosting.java
@@ -52,4 +52,25 @@ public class JobPosting extends BaseEntity {
                 .company(company)
                 .build();
     }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setPosition(String position) {
+        this.position = position;
+    }
+
+    public void setReward(Long reward) {
+        this.reward = reward;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setTechStacks(List<String> techStacks) {
+        this.techStacks = techStacks;
+    }
+
 }

--- a/src/main/java/com/wanted/service/ImageService.java
+++ b/src/main/java/com/wanted/service/ImageService.java
@@ -1,0 +1,59 @@
+package com.wanted.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.wanted.enums.ImageDirectory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String saveFile(MultipartFile multipartFile,
+                           ImageDirectory imageDirectory) throws IOException {
+
+        // 파일 이름에 이미지 타입에 대한 경로 및 UUID와 원래 파일의 확장자를 포함
+        String originalFileName = imageDirectory.getString() + "/" +
+                UUID.randomUUID() + "." + getFileExtension(multipartFile);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        // 파일 업로드
+        amazonS3.putObject(
+                bucket, originalFileName, multipartFile.getInputStream(), metadata
+        );
+
+        // 업로드한 파일의 URL 반환
+        return amazonS3.getUrl(bucket, originalFileName).toString();
+    }
+
+    public void deleteFile(String imagePath) {
+        // 파일 삭제
+        amazonS3.deleteObject(bucket, imagePath);
+    }
+
+    private String getFileExtension(MultipartFile file) {
+        // 파일 이름에서 확장자 추출
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename != null) {
+            int lastDotIndex = originalFilename.lastIndexOf(".");
+            if (lastDotIndex != -1) {
+                return originalFilename.substring(lastDotIndex + 1);
+            }
+        }
+        return ""; // 확장자가 없는 경우 빈 문자열 반환
+    }
+}

--- a/src/main/java/com/wanted/service/JobPostingService.java
+++ b/src/main/java/com/wanted/service/JobPostingService.java
@@ -1,6 +1,10 @@
 package com.wanted.service;
 
-import com.wanted.dto.jobposting.*;
+import com.wanted.dto.JobPostingModificationRequest;
+import com.wanted.dto.jobposting.JobPostingDetailDto;
+import com.wanted.dto.jobposting.JobPostingDto;
+import com.wanted.dto.jobposting.JobPostingRegistrationRequest;
+import com.wanted.dto.jobposting.JobPostingRelationsDto;
 import com.wanted.exception.CustomException;
 import com.wanted.exception.ErrorCode;
 import com.wanted.model.Company;
@@ -13,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -52,6 +57,28 @@ public class JobPostingService {
                         .collect(Collectors.toList());
 
         return JobPostingDetailDto.from(targetJobPosting, relations);
+    }
+
+    public void modifyJobPosting(Long id,
+                                 JobPostingModificationRequest ModificationRequestDto) {
+
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        // 빈값이거나 null 이 아닌 경우에만 수정
+        updateIfNotNull(jobPosting::setContent, ModificationRequestDto.getContent());
+        updateIfNotNull(jobPosting::setImageUrl, ModificationRequestDto.getImageUrl());
+        updateIfNotNull(jobPosting::setReward, ModificationRequestDto.getReward());
+        updateIfNotNull(jobPosting::setPosition, ModificationRequestDto.getPosition());
+        updateIfNotNull(jobPosting::setTechStacks, ModificationRequestDto.getTechStacks());
+
+        jobPostingRepository.save(jobPosting);
+    }
+
+    private <T> void updateIfNotNull(Consumer<T> setter, T value) {
+        if (value != null && (!(value instanceof String) || !((String) value).isEmpty())) {
+            setter.accept(value);
+        }
     }
 
 }

--- a/src/test/java/com/wanted/service/JobPostingServiceTest.java
+++ b/src/test/java/com/wanted/service/JobPostingServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.service;
 
+import com.wanted.dto.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.JobPostingDetailDto;
 import com.wanted.dto.jobposting.JobPostingDto;
 import com.wanted.dto.jobposting.JobPostingRegistrationRequest;
@@ -230,6 +231,55 @@ public class JobPostingServiceTest {
         assertThatThrownBy(() -> jobPostingService.getJobPostingDetails(nonExistentCompanyId))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.JOB_POSTING_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("채용공고 정보 수정 - 성공")
+    void testModifyJobPosting_success() {
+        // Give
+        JobPosting targetJobPosting = JobPosting.builder()
+                .id(1L)
+                .title("테스트 공고")
+                .company(Company.builder()
+                        .id(1L)
+                        .email("test@naver.com")
+                        .phone("010-1234-1234")
+                        .address("서울시 강남구")
+                        .name("테스트")
+                        .businessNumber("123-45-67890")
+                        .build())
+                .content("테스트입니다")
+                .imageUrl("테스트입니다")
+                .position("대리")
+                .reward(50000L)
+                .techStacks(Arrays.asList("Java", "Spring"))
+                .build();
+
+        JobPostingModificationRequest modificationRequestDto =
+                JobPostingModificationRequest.builder()
+                        .content("변경입니다")
+                        .imageUrl("변경입니다")
+                        .reward(1000L)
+                        .position("")
+                        .title(null)
+                        .techStacks(Arrays.asList("변경1" , "변경2"))
+                        .build();
+
+        when(jobPostingRepository.findById(targetJobPosting.getId()))
+                .thenReturn(Optional.of(targetJobPosting));
+
+        // When
+        jobPostingService.modifyJobPosting(
+                targetJobPosting.getId(), modificationRequestDto
+        );
+
+        // Then
+        assertThat(targetJobPosting.getContent()).isEqualTo("변경입니다");
+        assertThat(targetJobPosting.getImageUrl()).isEqualTo("변경입니다");
+        assertThat(targetJobPosting.getReward()).isEqualTo(1000);
+        assertThat(targetJobPosting.getPosition()).isEqualTo("대리");
+        assertThat(targetJobPosting.getTechStacks()).isEqualTo(Arrays.asList("변경1", "변경2"));
+        verify(jobPostingRepository, times(1)).save(targetJobPosting);
     }
 
 }


### PR DESCRIPTION
### 작업 내용
- 채용공고 (또는 기업의 프로필 등..)에 사용될 이미지를 업로드 하는 기능 구현
### 변경 사항(추가시엔 추가사항)
- `S3`의 `bucket`을 이용하여 이미지를 업로드 (호스팅 주소 URL반환)하는 기능을 추가.
### 특이 사항
- 해당 주소를 채용공고 등록 시 `imageURL`필드에 입력하여 등록요청을 하여야 함.
- 해당 서비스는 `S3`에 업로드/삭제/URL읽기 외 별도 로직이 존재하지 않으므로 테스트코드 없이 API테스트만 진행 

