### PR TITLE
Feat: 채용공고 검색 기능 추가 및 서비스 별 Member 권한 검증 실시 

### DIFF
--- a/src/main/java/com/wanted/controller/ImageController.java
+++ b/src/main/java/com/wanted/controller/ImageController.java
@@ -1,6 +1,6 @@
 package com.wanted.controller;
 
-import com.wanted.dto.ImageUrlResponse;
+import com.wanted.dto.image.ImageUrlResponse;
 import com.wanted.enums.ImageDirectory;
 import com.wanted.service.ImageService;
 import io.swagger.annotations.Api;

--- a/src/main/java/com/wanted/controller/JobPostingController.java
+++ b/src/main/java/com/wanted/controller/JobPostingController.java
@@ -1,6 +1,6 @@
 package com.wanted.controller;
 
-import com.wanted.dto.JobPostingModificationRequest;
+import com.wanted.dto.jobposting.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.*;
 import com.wanted.service.ImageService;
 import com.wanted.service.JobPostingService;
@@ -36,45 +36,62 @@ public class JobPostingController {
     }
 
     @GetMapping
-    @ApiOperation(value = "채용공고 조회", notes = "채용공고를 조회합니다.")
-    public ResponseEntity<JobPostingListResponse> getJobPostings() {
+    @ApiOperation(
+            value = "채용공고 검색/조회",
+            notes = "쿼리스트링을 사용하지 않을 경우 전체 채용공고를 조회합니다." +
+                    "쿼리스트링을 사용한 값에 대해서는 해당 값으로 필터링된 채용공고를 조회합니다."
+    )
+    public ResponseEntity<JobPostingListResponse> getJobPostings(
+            @RequestParam(required = false) String titleKeyword,
+            @RequestParam(required = false) String techStackKeyword,
+            @RequestParam(required = false) String regionKeyword,
+            @RequestParam(required = false) String positionKeyword
+    ) {
 
-        List<JobPostingDto> jobPostingResponseDto =
-                jobPostingService.getJobPostings();
+        List<JobPostingDto> jobPostings = jobPostingService.getJobPostings(
+                titleKeyword, techStackKeyword, regionKeyword, positionKeyword
+        );
 
         return ResponseEntity.status(OK)
-                .body(JobPostingListResponse.from(jobPostingResponseDto));
+                .body(JobPostingListResponse.from(jobPostings));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{jobPostingId}")
     @ApiOperation(value = "채용공고 상세 조회", notes = "채용공고 상세정보를 조회합니다.")
     public ResponseEntity<JobPostingDetailResponse> getJobPostings(
-            @PathVariable Long id) {
+            @PathVariable Long jobPostingId) {
 
         JobPostingDetailDto jobPostingDetailDto =
-                jobPostingService.getJobPostingDetails(id);
+                jobPostingService.getJobPostingDetails(jobPostingId);
 
         return ResponseEntity.status(OK)
                 .body(JobPostingDetailResponse.from(jobPostingDetailDto));
     }
 
-    @PatchMapping("/{id}")
+    // 사전 과제에서는 토큰인증 과정이 생략되므로 직접 MemberId를 받아 검증하도록 구현
+    @PatchMapping("/{jobPostingId}/member/{memberId}")
     @ApiOperation(value = "채용공고 수정", notes = "채용공고 내용을 수정합니다. (수정안하는 필드는 null로 보내주세요.)")
     public ResponseEntity<Void> modifyJobPosting(
-            @PathVariable Long id,
+            @PathVariable Long jobPostingId,
+            @PathVariable Long memberId,
             @Valid @RequestBody JobPostingModificationRequest jobPostingModificationRequestDto) {
 
-        jobPostingService.modifyJobPosting(id,jobPostingModificationRequestDto);
+        jobPostingService.modifyJobPosting(
+                jobPostingId, jobPostingModificationRequestDto, memberId
+        );
 
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @DeleteMapping("/{id}")
+    // 사전 과제에서는 토큰인증 과정이 생략되므로 직접 MemberId를 받아 검증하도록 구현
+    @DeleteMapping("/{jobPostingId}/member/{memberId}")
     @ApiOperation(value = "채용공고 삭제", notes = "채용공고를 삭제합니다.")
     public ResponseEntity<Void> deleteJobPosting(
-            @PathVariable Long id) {
+            @PathVariable Long jobPostingId,
+            @PathVariable Long memberId) {
 
-        String targetImageUrl = jobPostingService.deleteJobPosting(id);
+        String targetImageUrl =
+                jobPostingService.deleteJobPosting(jobPostingId, memberId);
 
         //채용공고 삭제 시 공고이미지도 삭제
         imageService.deleteFile(targetImageUrl);

--- a/src/main/java/com/wanted/dto/company/CompanyDto.java
+++ b/src/main/java/com/wanted/dto/company/CompanyDto.java
@@ -1,6 +1,6 @@
 package com.wanted.dto.company;
 
-import com.wanted.model.Company;
+import com.wanted.model.Member;
 import io.swagger.annotations.Api;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,18 +16,16 @@ public class CompanyDto {
     private Long id;
     private String email;
     private String name;
-    private String address;
     private String phone;
     private String imageUrl;
 
-    public static CompanyDto from(Company company) {
+    public static CompanyDto from(Member member) {
         return CompanyDto.builder()
-                .id(company.getId())
-                .email(company.getEmail())
-                .name(company.getName())
-                .address(company.getAddress())
-                .phone(company.getPhone())
-                .imageUrl(company.getImageUrl())
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .imageUrl(member.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/wanted/dto/image/ImageUrlResponse.java
+++ b/src/main/java/com/wanted/dto/image/ImageUrlResponse.java
@@ -1,4 +1,4 @@
-package com.wanted.dto;
+package com.wanted.dto.image;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/wanted/dto/jobposting/JobPostingDto.java
+++ b/src/main/java/com/wanted/dto/jobposting/JobPostingDto.java
@@ -16,6 +16,9 @@ public class JobPostingDto {
     private String title;
     private String companyName;
     private String position;
+    private String email;
+    private String country;
+    private String region;
     private Long reward;
     private List<String> techStacks;
 
@@ -24,8 +27,11 @@ public class JobPostingDto {
                 .id(jobPosting.getId())
                 .imageUrl(jobPosting.getImageUrl())
                 .title(jobPosting.getTitle())
-                .companyName(jobPosting.getCompany().getName())
+                .companyName(jobPosting.getMember().getName())
                 .position(jobPosting.getPosition())
+                .email(jobPosting.getMember().getEmail())
+                .country(jobPosting.getCountry())
+                .region(jobPosting.getRegion())
                 .reward(jobPosting.getReward())
                 .techStacks(jobPosting.getTechStacks())
                 .build();

--- a/src/main/java/com/wanted/dto/jobposting/JobPostingModificationRequest.java
+++ b/src/main/java/com/wanted/dto/jobposting/JobPostingModificationRequest.java
@@ -1,4 +1,4 @@
-package com.wanted.dto;
+package com.wanted.dto.jobposting;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +15,8 @@ public class JobPostingModificationRequest {
     private String title;
     private String imageUrl;
     private String position;
+    private String country;
+    private String region;
     private Long reward;
     private String content;
     private List<String> techStacks;

--- a/src/main/java/com/wanted/enums/MemberRole.java
+++ b/src/main/java/com/wanted/enums/MemberRole.java
@@ -1,0 +1,12 @@
+package com.wanted.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MemberRole {
+    COMPANY("ROLE_COMPANY"),
+    JOB_SEEKER("ROLE_JOB_SEEKER");
+    private final String string;
+}

--- a/src/main/java/com/wanted/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/exception/ErrorCode.java
@@ -15,7 +15,13 @@ public enum ErrorCode {
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회사입니다."),
 
     // 채용공고 Exception
-    JOB_POSTING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채용공고입니다.");
+    JOB_POSTING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채용공고입니다."),
+    NOT_COMPANY_MEMBER(HttpStatus.FORBIDDEN, "기업 회원만 사용가능한 서비스 입니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN,"해당 채용공고의 수정/삭제 권한이 없습니다." ),
+
+    // 구직자 관련 Exception
+    JOB_SEEKER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 구직자입니다."),
+    NOT_JOB_SEEKER_MEMBER(HttpStatus.FORBIDDEN,"구직자 회원만 사용가능한 서비스 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/wanted/model/JobPosting.java
+++ b/src/main/java/com/wanted/model/JobPosting.java
@@ -23,11 +23,13 @@ public class JobPosting extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "company", referencedColumnName = "id")
-    private Company company;
+    @JoinColumn(name = "member", referencedColumnName = "id")
+    private Member member;
 
     private String title;
     private String imageUrl;
+    private String country;
+    private String region;
     private String position;
     private Long reward;
     private String content;
@@ -42,7 +44,7 @@ public class JobPosting extends BaseEntity {
 
     public static JobPosting from(
             JobPostingRegistrationRequest jobPostingRequestDto,
-            Company company) {
+            Member member) {
         return JobPosting.builder()
                 .title(jobPostingRequestDto.getTitle())
                 .imageUrl(jobPostingRequestDto.getImageUrl())
@@ -50,7 +52,7 @@ public class JobPosting extends BaseEntity {
                 .reward(jobPostingRequestDto.getReward())
                 .content(jobPostingRequestDto.getContent())
                 .techStacks(jobPostingRequestDto.getTechStacks())
-                .company(company)
+                .member(member)
                 .build();
     }
 
@@ -73,5 +75,13 @@ public class JobPosting extends BaseEntity {
     public void setTechStacks(List<String> techStacks) {
         this.techStacks = techStacks;
     }
-
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public void setCountry(String country) {
+        this.country = country;
+    }
+    public void setRegion(String region) {
+        this.region = region;
+    }
 }

--- a/src/main/java/com/wanted/model/Member.java
+++ b/src/main/java/com/wanted/model/Member.java
@@ -1,21 +1,19 @@
 package com.wanted.model;
 
+import com.wanted.enums.MemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
-public class Company extends BaseEntity {
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,12 +25,14 @@ public class Company extends BaseEntity {
 
     private String name;
 
-    private String address;
-
     private String phone;
 
+    //해당 필드는 기업의 경우에만 사용 (추후 서비스 확장가능성을 위해 - openApi 를 통한 기업 인증 등..)
     private String businessNumber;
 
     private String imageUrl;
 
+    //회원의 타입을 나타내는 필드 (기업/구직자)
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
 }

--- a/src/main/java/com/wanted/repository/JobPostingRepository.java
+++ b/src/main/java/com/wanted/repository/JobPostingRepository.java
@@ -1,8 +1,10 @@
 package com.wanted.repository;
 
-import com.wanted.model.Company;
 import com.wanted.model.JobPosting;
+import com.wanted.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +12,18 @@ import java.util.List;
 @Repository
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
 
-    List<JobPosting> findByCompany(Company company);
+    List<JobPosting> findByMember(Member member);
+
+    @Query("SELECT jp FROM JobPosting jp WHERE " +
+            "(:titleKeyword IS NULL OR jp.title IS NULL OR jp.title LIKE %:titleKeyword%) " +
+            "AND (:techStackKeyword IS NULL OR jp.techStacks IS EMPTY OR :techStackKeyword MEMBER OF jp.techStacks) " +
+            "AND (:regionKeyword IS NULL OR jp.region IS NULL OR jp.region LIKE %:regionKeyword%) " +
+            "AND (:positionKeyword IS NULL OR jp.position IS NULL OR jp.position LIKE %:positionKeyword%)")
+    List<JobPosting> customSearch(
+            @Param("titleKeyword") String titleKeyword,
+            @Param("techStackKeyword") String techStackKeyword,
+            @Param("regionKeyword") String regionKeyword,
+            @Param("positionKeyword") String positionKeyword
+    );
 
 }

--- a/src/main/java/com/wanted/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/repository/MemberRepository.java
@@ -1,12 +1,12 @@
 package com.wanted.repository;
 
-import com.wanted.model.Company;
+import com.wanted.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface CompanyRepository extends JpaRepository<Company, Long> {
-    Optional<Company> findByEmail(String email);
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/wanted/service/JobPostingService.java
+++ b/src/main/java/com/wanted/service/JobPostingService.java
@@ -1,16 +1,17 @@
 package com.wanted.service;
 
-import com.wanted.dto.JobPostingModificationRequest;
+import com.wanted.dto.jobposting.JobPostingModificationRequest;
 import com.wanted.dto.company.CompanyDto;
 import com.wanted.dto.jobposting.JobPostingDetailDto;
 import com.wanted.dto.jobposting.JobPostingDto;
 import com.wanted.dto.jobposting.JobPostingRegistrationRequest;
 import com.wanted.dto.jobposting.JobPostingRelationsDto;
+import com.wanted.enums.MemberRole;
 import com.wanted.exception.CustomException;
 import com.wanted.exception.ErrorCode;
-import com.wanted.model.Company;
+import com.wanted.model.Member;
 import com.wanted.model.JobPosting;
-import com.wanted.repository.CompanyRepository;
+import com.wanted.repository.MemberRepository;
 import com.wanted.repository.JobPostingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,21 +27,32 @@ import java.util.stream.Collectors;
 public class JobPostingService {
 
     private final JobPostingRepository jobPostingRepository;
-    private final CompanyRepository companyRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void addJobPosting(JobPostingRegistrationRequest jobPostingRequestDto) {
 
-        Company company = companyRepository
+        Member member = memberRepository
                 .findByEmail(jobPostingRequestDto.getCompanyEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
 
-        jobPostingRepository.save(JobPosting.from(jobPostingRequestDto, company));
+        // 사전과제 요구사항에서 인증이 생략되었기 때문에 서비스레이어에서 직접 검증
+        validateMemberIsCompany(member);
+
+        JobPosting jobPosting = JobPosting.from(jobPostingRequestDto, member);
+        jobPostingRepository.save(jobPosting);
     }
 
-    public List<JobPostingDto> getJobPostings() {
+    public List<JobPostingDto> getJobPostings(String titleKeyword,
+                                              String techStackKeyword,
+                                              String regionKeyword,
+                                              String positionKeyword) {
 
-        return jobPostingRepository.findAll().stream()
+        List<JobPosting> jobPostingsSearched = jobPostingRepository.customSearch(
+                titleKeyword, techStackKeyword, regionKeyword, positionKeyword
+        );
+
+        return jobPostingsSearched.stream()
                 .map(JobPostingDto::from)
                 .collect(Collectors.toList());
     }
@@ -51,28 +63,32 @@ public class JobPostingService {
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
 
         List<JobPostingRelationsDto> relations =
-                jobPostingRepository.findByCompany(targetJobPosting.getCompany())
+                jobPostingRepository.findByMember(targetJobPosting.getMember())
                         .stream()
                         .filter(jobPosting -> !Objects.equals(jobPosting.getId(), companyId))
                         .map(JobPostingRelationsDto::from)
                         .collect(Collectors.toList());
 
-        Company company = companyRepository.findById(targetJobPosting.getCompany().getId())
+        Member member = memberRepository.findById(targetJobPosting.getMember().getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
 
         return JobPostingDetailDto.from(
                 JobPostingDto.from(targetJobPosting),
-                CompanyDto.from(company),
+                CompanyDto.from(member),
                 targetJobPosting.getContent(),
                 relations
         );
     }
 
-    public void modifyJobPosting(Long id,
-                                 JobPostingModificationRequest ModificationRequestDto) {
+    public void modifyJobPosting(Long jobPostingId,
+                                 JobPostingModificationRequest ModificationRequestDto,
+                                 Long memberId) {
 
-        JobPosting jobPosting = jobPostingRepository.findById(id)
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        // 권한 검증(본인의 게시물 인지)
+        checkPermission(jobPosting, memberId);
 
         // 빈값이거나 null 이 아닌 경우에만 수정
         updateIfNotNull(jobPosting::setContent, ModificationRequestDto.getContent());
@@ -80,6 +96,9 @@ public class JobPostingService {
         updateIfNotNull(jobPosting::setReward, ModificationRequestDto.getReward());
         updateIfNotNull(jobPosting::setPosition, ModificationRequestDto.getPosition());
         updateIfNotNull(jobPosting::setTechStacks, ModificationRequestDto.getTechStacks());
+        updateIfNotNull(jobPosting::setTitle, ModificationRequestDto.getTitle());
+        updateIfNotNull(jobPosting::setCountry, ModificationRequestDto.getCountry());
+        updateIfNotNull(jobPosting::setRegion, ModificationRequestDto.getRegion());
 
         jobPostingRepository.save(jobPosting);
     }
@@ -90,10 +109,17 @@ public class JobPostingService {
         }
     }
 
-    public String deleteJobPosting(Long id) {
+    @Transactional
+    public String deleteJobPosting(Long jobPostingId, Long memberId) {
 
-        JobPosting jobPosting = jobPostingRepository.findById(id)
+        JobPosting jobPosting = jobPostingRepository.findById(jobPostingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+        // 권한 검증(본인의 게시물 인지)
+        checkPermission(jobPosting, memberId);
+
+        // 사전과제 요구사항에서 인증이 생략되었기 때문에 서비스레이어에서 직접 검증
+        validateMemberIsCompany(jobPosting.getMember());
 
         String imageUrl = jobPosting.getImageUrl();
 
@@ -102,4 +128,15 @@ public class JobPostingService {
         return imageUrl;
     }
 
+    private void validateMemberIsCompany(Member member) {
+        if (member.getRole() != MemberRole.COMPANY) {
+            throw new CustomException(ErrorCode.NOT_COMPANY_MEMBER);
+        }
+    }
+
+    private void checkPermission(JobPosting jobPosting, Long memberId) {
+        if (!jobPosting.getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED);
+        }
+    }
 }


### PR DESCRIPTION
### 작업 내용
- Dto 파일의 상위 디렉토리 네이밍 수정
- `Company` 엔티티 필드 수정 - 구직자 및 회사 엔티티 통합 
- 채용공고 검색 기능 추가 및 서비스 별 `Member` 권한 검증 실시
### 변경 사항(추가시엔 추가사항)
- 구직자와 기업 엔티티는 사실 1~2개의 필드를 제외하면 동일한 필드들을
가지고있으므로 `Company` 엔티티의 필드를 수정하여 구직자와 회사 엔티티를
통합 관리 할 수 있도록 수정
- 기존의 채용공고 전체조회 기능과 채용공고 전체조회 기능을 병합하여 코드의 효율성을 극대화.
쿼리스트링을 함께 요청에 넘기면 검색기능을 수행하고,
쿼리스트링을 생략하여 요청을 넘기면 전체조회 기능을 수행함.
이외에도 인증절차가 생략된 프로젝트 이므로 직접 회원의 id를 받아
서비스권한에 대한 검증 실시

### 특이 사항
- 기존의 `Company` 엔티티를 수정하여 구직자도 함께 관리되도록 하였음.
- 프로젝트 구조 일관화 및 유지보수를 위해 일부 디렉토리명을 수정