### PR TITLE
Merge: 채용공고 등록 기능 수정 (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
       <td>채용공고 API</td>
       <td>채용공고 등록</td>
       <td><code>POST</code></td>
-      <td><code>/api/job-postings</code></td>
+      <td><code>/api/job-postings/member/{memberId}</code></td>
       <td>
       <pre><code>
 {
@@ -247,13 +247,14 @@
 </details>
 
 - [x] **프로젝트 구현 및 배포**
-    - 프로젝트는 Spring Boot 기반으로 구현했습니다.
-    - 프로젝트는 AWS EC2/Docker 를 사용하여 배포했습니다.
+    - 프로젝트는 `Spring Boot` 기반으로 구현했습니다.
+    - 프로젝트는 `AWS EC2`/`Docker` 를 사용하여 배포했습니다.
     - 젠킨스로 CI/CD를 구성했습니다.
-    - DB는 AWS RDS의 MySQL을 사용했습니다
-    - 이미지 업로드는 AWS S3를 사용했습니다.
-    - 프로젝트는 Swagger를 사용하여 API 명세서를 작성했습니다.
-    - AssertJ를 사용하여 테스트코드를 작성했습니다.
+    - DB는 `AWS RDS`의 `MySQL`을 사용했습니다
+    - 이미지 업로드는 `AWS S3`를 사용했습니다.
+    - 프로젝트는 `Swagger`를 사용하여 API 명세서를 작성했습니다.
+    - `AssertJ`를 사용하여 테스트코드를 작성했습니다.
+    - `JobSeeker`와 `Company`는 하나의 `Member` Entity에 `Role` 필드로 역할을 구분해 구현했습니다.
 
 - [x] **채용공고 등록 구현**
     - 채용공고 등록 시 이미지 경로를 받아 _(이미지 업로드 API 따로 구현했습니다.)_ 공고이미지를 등록할 수 있도록 했습니다.

--- a/src/main/java/com/wanted/controller/JobPostingController.java
+++ b/src/main/java/com/wanted/controller/JobPostingController.java
@@ -1,6 +1,5 @@
 package com.wanted.controller;
 
-import com.wanted.dto.jobposting.JobPostingModificationRequest;
 import com.wanted.dto.jobposting.*;
 import com.wanted.service.ImageService;
 import com.wanted.service.JobPostingService;
@@ -11,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-
 import java.util.List;
 
 import static org.springframework.http.HttpStatus.*;
@@ -25,12 +23,13 @@ public class JobPostingController {
     private final JobPostingService jobPostingService;
     private final ImageService imageService;
 
-    @PostMapping
+    @PostMapping("/member/{memberId}")
     @ApiOperation(value = "채용공고 등록", notes = "채용공고를 등록합니다.")
     public ResponseEntity<Void> addJobPosting(
+            @PathVariable Long memberId,
             @Valid @RequestBody JobPostingRegistrationRequest jobPostingRequestDto) {
 
-        jobPostingService.addJobPosting(jobPostingRequestDto);
+        jobPostingService.addJobPosting(memberId, jobPostingRequestDto);
 
         return ResponseEntity.status(CREATED).build();
     }

--- a/src/main/java/com/wanted/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.repository;
 
+import com.wanted.enums.MemberRole;
 import com.wanted.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByIdAndRole(Long memberId, MemberRole memberRole);
 }

--- a/src/main/java/com/wanted/service/JobPostingService.java
+++ b/src/main/java/com/wanted/service/JobPostingService.java
@@ -2,7 +2,6 @@ package com.wanted.service;
 
 import com.wanted.dto.company.CompanyDto;
 import com.wanted.dto.jobposting.*;
-import com.wanted.enums.MemberRole;
 import com.wanted.exception.CustomException;
 import com.wanted.model.JobPosting;
 import com.wanted.model.Member;
@@ -17,6 +16,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static com.wanted.enums.MemberRole.COMPANY;
 import static com.wanted.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
@@ -27,10 +27,11 @@ public class JobPostingService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void addJobPosting(JobPostingRegistrationRequest jobPostingRequestDto) {
+    public void addJobPosting(Long memberId,
+                              JobPostingRegistrationRequest jobPostingRequestDto) {
 
         Member member = memberRepository
-                .findByEmail(jobPostingRequestDto.getCompanyEmail())
+                .findByIdAndRole(memberId, COMPANY)
                 .orElseThrow(() -> new CustomException(COMPANY_NOT_FOUND));
 
         // 사전과제 요구사항에서 인증이 생략되었기 때문에 서비스레이어에서 직접 검증
@@ -110,7 +111,7 @@ public class JobPostingService {
     }
 
     private void validateMemberIsCompany(Member member) {
-        if (member.getRole() != MemberRole.COMPANY) {
+        if (member.getRole() != COMPANY) {
             throw new CustomException(NOT_COMPANY_MEMBER);
         }
     }


### PR DESCRIPTION
### 작업 내용
- 채용공고 등록 시 회사의 id를 경로변수로 전달받아 검증 하고 등록.
### 변경 사항(추가시엔 추가사항)
- 기존에는 json데이터로 받은 email으로 검색하여 검증하였으나 해당 프로젝트는 인증절차가 생략된 프로젝트이고
- 타 API들과 통일성을 가져가기위해 경로에 변수 받기로 결정
### 특이 사항
- 관련하여 테스트코드/README 수정

